### PR TITLE
Message from server show in GUI for post responses

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+client/
+kv/target/
+kv/Cargo.lock

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 .git/
 client/
 kv/target/
-kv/Cargo.lock

--- a/client/PyMOL-KVFinder-web-tools/__init__.py
+++ b/client/PyMOL-KVFinder-web-tools/__init__.py
@@ -300,7 +300,7 @@ class PyMOLKVFinderWebTools(QMainWindow):
                     "Job successfully submitted to KVFinder-web server!",
                     self.job.id,
                     status=None,
-                    notification=reply['msg'],
+                    notification=notification,
                     )
                 message.exec_()
 

--- a/client/PyMOL-KVFinder-web-tools/__init__.py
+++ b/client/PyMOL-KVFinder-web-tools/__init__.py
@@ -36,7 +36,10 @@ worker = None
 
 
 ########## Relevant information ##########
-# Server                                 #
+# Server (KVFinder-web server)           #
+# This variable defines the url of the   #
+# KVFinder-web server. Change this       #
+# variable to the server you are using   #
 server = "http://localhost"              #
 #                                        #
 # Days until job expire                  #
@@ -63,7 +66,6 @@ times_job_completed_no_checked = 500     #
 # 3: Print all information (Worker/GUI)  #
 verbosity = 0                            #
 ##########################################
-
 
 
 class _Default(object):
@@ -293,9 +295,12 @@ class PyMOLKVFinderWebTools(QMainWindow):
                     print('> Job successfully submitted to KVFinder-web server!') 
 
                 # Message to user
+                notification = reply['msg'] if reply['msg'] != '' else None
                 message = Message(
                     "Job successfully submitted to KVFinder-web server!",
-                    self.job.id
+                    self.job.id,
+                    status=None,
+                    notification=reply['msg'],
                     )
                 message.exec_()
 
@@ -320,10 +325,12 @@ class PyMOLKVFinderWebTools(QMainWindow):
                         print('> Job already completed in KVFinder-web server!')
                     
                     # Message to user
+                    notification = reply['output']['msg'] if reply['output']['msg'] != '' else None
                     message = Message(
                         "Job already completed in KVFinder-web server!\nDisplaying results ...",
                         self.job.id,
-                        status
+                        status=status,
+                        notification=notification,
                         )
                     message.exec_()
 
@@ -356,10 +363,12 @@ class PyMOLKVFinderWebTools(QMainWindow):
                         print('> Job already submitted to KVFinder-web server!') 
 
                     # Message to user
+                    notification = reply['output']['msg'] if reply['output']['msg'] != '' else None
                     message = Message(
                         "Job already submitted to KVFinder-web server!",
                         self.job.id,
-                        status
+                        status=status,
+                        notification=notification,
                         )
                     message.exec_()
 
@@ -1257,7 +1266,11 @@ class PyMOLKVFinderWebTools(QMainWindow):
             # Message to user
             if verbosity in [1, 3]:
                 print("> Job successfully added!")
-            message = Message("Job successfully added!", job.id, job.status)
+            message = Message(
+                "Job successfully added!", 
+                job.id, 
+                job.status
+                )
             message.exec_()
 
             # Include job to available jobs
@@ -1802,7 +1815,6 @@ class Job(object):
                         cmd.save(self.ligand, parameters['files']['ligand'], 0,  'pdb')
         # Request information (server)
         # Input PDB
-        print(self.pdb)
         if self.pdb:
             self._add_pdb(self.pdb)
         # Ligand PDB
@@ -2375,16 +2387,16 @@ class Form(QDialog):
 class Message(QDialog):
 
 
-    def __init__(self, msg: str, job_id: str, status: Optional[str]=None):
+    def __init__(self, msg: str, job_id: str, status: Optional[str]=None, notification: Optional[str]=None):
         super(Message, self).__init__()
         # Initialize Message GUI
-        self.initialize_gui(msg, job_id, status)
+        self.initialize_gui(msg, job_id, status, notification)
 
         # Set Values in Message GUI
-        self.set_values(msg, job_id, status)
+        self.set_values(msg, job_id, status, notification)
 
 
-    def set_values(self, msg, job_id, status) -> None:
+    def set_values(self, msg, job_id, status, notification) -> None:
         # Message
         self.msg.setText(msg)
 
@@ -2398,10 +2410,14 @@ class Message(QDialog):
                 self.status.setStyleSheet('color: blue;')
             elif status == 'completed':
                 self.status.setStyleSheet('color: green;')
+        
+        # Notification
+        if notification:
+            self.notification.setText(notification)
 
 
-    def initialize_gui(self, msg, job_id, status) -> None:
-        from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QSpacerItem, QSizePolicy, QDialogButtonBox, QStyle
+    def initialize_gui(self, msg, job_id, status, notification) -> None:
+        from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QTextEdit, QSpacerItem, QSizePolicy, QDialogButtonBox, QStyle
         from PyQt5.QtCore import Qt
         from PyQt5.QtGui import QFont, QIcon
         
@@ -2410,7 +2426,7 @@ class Message(QDialog):
 
         # Set alignment of QDialog
         self.vframe = QVBoxLayout(self)
-        self.setFixedSize(425, 150)
+        self.setFixedSize(425, 200)
 
         # Create message layout
         self.hframe1 = QHBoxLayout()
@@ -2470,6 +2486,18 @@ class Message(QDialog):
             self.hframe3.addWidget(self.status)
             self.hframe3.setAlignment(Qt.AlignCenter)
 
+        # Create Notification layout
+        self.hframe4 = QHBoxLayout()
+        if notification:
+            # Notification entry
+            self.notification = QTextEdit(self)
+            self.notification.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding))
+            self.notification.setReadOnly(True)
+            self.notification.setAlignment(Qt.AlignCenter)
+            # add to layout
+            self.hframe4.addWidget(self.notification)
+            self.hframe4.setAlignment(Qt.AlignCenter)
+
         # Vertical spacer
         self.vspacer2 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
@@ -2484,6 +2512,7 @@ class Message(QDialog):
         self.vframe.addItem(self.vspacer1)
         self.vframe.addLayout(self.hframe2)
         self.vframe.addLayout(self.hframe3)
+        self.vframe.addLayout(self.hframe4)
         self.vframe.addItem(self.vspacer2)
         self.vframe.addWidget(self.buttonBox)
 

--- a/kv/src/lib.rs
+++ b/kv/src/lib.rs
@@ -128,6 +128,7 @@ mod kv {
     struct Data {
         tags: [String;1],
         input: Input,
+        msg: String,
     }
 
     pub mod worker {
@@ -375,6 +376,7 @@ mod kv {
                 // create a tag using function hash64 applied to input (unique value per input)
                 tags: [city::hash64(serde_json::to_string(&input).unwrap()).to_string()],
                 input,
+                msg: String::from("Testing notification\nThere are a new plugin version available, please download it from our github to use new features!"),
             };
             let create_job = || {
                 let client = reqwest::Client::new();
@@ -383,7 +385,7 @@ mod kv {
                     .json(&data)
                     .send();
                 match response {
-                    Ok(_) => HttpResponse::Ok().json(json!({"id":data.tags[0]})),
+                    Ok(_) => HttpResponse::Ok().json(json!({"id":data.tags[0], "msg": data.msg})),
                     Err(e) => HttpResponse::InternalServerError().body(format!("{:?}", e)),
                 }
             };


### PR DESCRIPTION
This pull request includes:

- **PyMOL KVFinder-web Tools** update:
  - Message class accepts:
    - notification (post response without created job - reply['msg']:1) from post responses (server) and show it on a QTextEdit;
![1](https://user-images.githubusercontent.com/20664153/108918282-e300ce80-760f-11eb-8ae5-c09ee13a9043.png)
    - message (post response with created job - reply['output']['msg']:2) from post responses (server) and show it on a QTextEdit;
![2](https://user-images.githubusercontent.com/20664153/108918287-e431fb80-760f-11eb-9952-d8cb634d5fc4.png)

- **kvserver** update:
  - `Data {}` now include `notification` string;
  - `create_job` send a dummy message ("Testing notification\nThere are a new plugin version available, please download it from our github to use new features!") from server to GUI.

